### PR TITLE
Antelope : Permission Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ graph TD;
   - [ ] **Savanna Merkle Roots**
 - [x] **Transactions**
   - [ ] **Feature Operations**
-  - [ ] **Permission Operations**
+  - [x] **Permission Operations**
   - [ ] **RAM Operations**
   - [ ] **Table Operations**
   - [ ] **Creation Tree**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Substreams Raw Blocks
 
 ## `EVM` Raw Blockchain Data
+>
 > Ethereum, Base, Arbitrum One, Polygon, BNB...
 > [`sf.ethereum.type.v2.Block`](https://buf.build/streamingfast/firehose-ethereum/docs/main:sf.ethereum.type.v2)
 
@@ -70,6 +71,9 @@ graph TD;
 - [x] **Transactions**
   - [x] **Feature Operations**
   - [x] **Permission Operations**
+    - [x] **Authority.Accounts**
+    - [x] **Authority.Keys**
+    - [x] **Authority.Waits**
   - [ ] **RAM Operations**
   - [ ] **Table Operations**
   - [ ] **Creation Tree**

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -127,22 +127,17 @@ CREATE TABLE IF NOT EXISTS perm_ops
 
     -- perm_op --
     operation                   LowCardinality(String),
+    operation_code              UInt8,
     action_index                UInt32,
-    old_perm_id                 UInt64,
-    old_perm_parent_id          UInt64,
-    old_perm_owner              String,
-    old_perm_name               String,
-    old_perm_last_updated       DateTime64(3, 'UTC'),
-    new_perm_id                 UInt64,
-    new_perm_parent_id          UInt64,
-    new_perm_owner              String,
-    new_perm_name               String,
-    new_perm_last_updated    DateTime64(3, 'UTC'),
+    id                          UInt64,
+    parent_id                   UInt64,
+    owner                       String,
+    name                        String,
     -- PermissionObject 'authority' missing
 )
     ENGINE = ReplacingMergeTree()
-        PRIMARY KEY (block_date, block_number)
-        ORDER BY (block_date, block_number, tx_hash, action_index)
+        PRIMARY KEY (tx_hash, action_index)
+        ORDER BY (tx_hash, action_index)
         COMMENT 'Antelope permission operations';
 
 CREATE TABLE IF NOT EXISTS actions

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -128,16 +128,16 @@ CREATE TABLE IF NOT EXISTS perm_ops
     -- perm_op --
     operation                   LowCardinality(String),
     action_index                UInt32,
-    old_perm_id           UInt64,
-    old_perm_parent_id    UInt64,
-    old_perm_owner        String,
-    old_perm_name         String,
-    -- old_perm_last_updated    DateTime64(3, 'UTC'),
-    new_perm_id           UInt64,
-    new_perm_parent_id    UInt64,
-    new_perm_owner        String,
-    new_perm_name         String,
-    -- new_perm_last_updated    DateTime64(3, 'UTC'),
+    old_perm_id                 UInt64,
+    old_perm_parent_id          UInt64,
+    old_perm_owner              String,
+    old_perm_name               String,
+    old_perm_last_updated       DateTime64(3, 'UTC'),
+    new_perm_id                 UInt64,
+    new_perm_parent_id          UInt64,
+    new_perm_owner              String,
+    new_perm_name               String,
+    new_perm_last_updated    DateTime64(3, 'UTC'),
     -- PermissionObject 'authority' missing
 )
     ENGINE = ReplacingMergeTree()

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -81,6 +81,42 @@ CREATE TABLE IF NOT EXISTS transactions
         ORDER BY (block_date, block_number, hash)
         COMMENT 'Antelope transactions';
 
+CREATE TABLE IF NOT EXISTS perm_ops
+(
+    -- clock --
+    block_time                  DateTime64(3, 'UTC'),
+    block_number                UInt64,
+    block_hash                  String COMMENT 'Hash',
+    block_date                  Date,
+
+    -- transaction --
+    tx_hash                     String COMMENT 'Hash',
+    tx_index                    UInt64,
+    tx_status                   LowCardinality(String),
+    tx_status_code              UInt8,
+    tx_success                  Bool,
+    
+    -- perm_op --
+    operation                   LowCardinality(String),
+    action_index                UInt32,
+    old_perm_id           UInt64,
+    old_perm_parent_id    UInt64,
+    old_perm_owner        String,
+    old_perm_name         String,
+    -- old_perm_last_updated    DateTime64(3, 'UTC'),
+    new_perm_id           UInt64,
+    new_perm_parent_id    UInt64,
+    new_perm_owner        String,
+    new_perm_name         String,
+    -- new_perm_last_updated    DateTime64(3, 'UTC'),
+    -- PermissionObject 'authority' missing
+)
+    ENGINE = ReplacingMergeTree()
+        PRIMARY KEY (block_date, block_number)
+        ORDER BY (block_date, block_number, tx_hash, action_index)
+        COMMENT 'Antelope permission operations';
+
+
 CREATE TABLE IF NOT EXISTS actions
 (
     -- clock --

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -133,6 +133,7 @@ CREATE TABLE IF NOT EXISTS perm_ops
     parent_id                   UInt64,
     owner                       String,
     name                        String,
+    threshold                   UInt32,
 )
     ENGINE = ReplacingMergeTree()
         PRIMARY KEY (tx_hash, action_index)

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -133,12 +133,90 @@ CREATE TABLE IF NOT EXISTS perm_ops
     parent_id                   UInt64,
     owner                       String,
     name                        String,
-    -- PermissionObject 'authority' missing
 )
     ENGINE = ReplacingMergeTree()
         PRIMARY KEY (tx_hash, action_index)
         ORDER BY (tx_hash, action_index)
         COMMENT 'Antelope permission operations';
+
+CREATE TABLE IF NOT EXISTS accounts
+(
+    -- clock --
+    block_time                  DateTime64(3, 'UTC'),
+    block_number                UInt64,
+    block_hash                  String COMMENT 'Hash',
+    block_date                  Date,
+
+    -- transaction --
+    tx_hash                     String COMMENT 'Hash',
+    tx_index                    UInt64,
+    tx_status                   LowCardinality(String),
+    tx_status_code              UInt8,
+    tx_success                  Bool,
+
+    -- authority.accounts --
+    `index`                     UInt32,
+    action_index                UInt32,
+    actor                       String,
+    permission                  LowCardinality(String),
+    weight                      UInt32,
+)
+    ENGINE = ReplacingMergeTree()
+        PRIMARY KEY (tx_hash, action_index)
+        ORDER BY (tx_hash, action_index, `index`)
+        COMMENT 'Antelope authority accounts';
+
+CREATE TABLE IF NOT EXISTS keys
+(
+    -- clock --
+    block_time                  DateTime64(3, 'UTC'),
+    block_number                UInt64,
+    block_hash                  String COMMENT 'Hash',
+    block_date                  Date,
+
+    -- transaction --
+    tx_hash                     String COMMENT 'Hash',
+    tx_index                    UInt64,
+    tx_status                   LowCardinality(String),
+    tx_status_code              UInt8,
+    tx_success                  Bool,
+
+    -- authority.keys --
+    `index`                     UInt32,
+    action_index                UInt32,
+    public_key                  String,
+    weight                      UInt32,
+)
+    ENGINE = ReplacingMergeTree()
+        PRIMARY KEY (tx_hash, action_index)
+        ORDER BY (tx_hash, action_index, `index`)
+        COMMENT 'Antelope authority keys';
+
+CREATE TABLE IF NOT EXISTS waits
+(
+    -- clock --
+    block_time                  DateTime64(3, 'UTC'),
+    block_number                UInt64,
+    block_hash                  String COMMENT 'Hash',
+    block_date                  Date,
+
+    -- transaction --
+    tx_hash                     String COMMENT 'Hash',
+    tx_index                    UInt64,
+    tx_status                   LowCardinality(String),
+    tx_status_code              UInt8,
+    tx_success                  Bool,
+
+    -- authority.waits --
+    `index`                     UInt32,
+    action_index                UInt32,
+    wait_sec                    UInt32,
+    weight                      UInt32,
+)
+    ENGINE = ReplacingMergeTree()
+        PRIMARY KEY (tx_hash, action_index)
+        ORDER BY (tx_hash, action_index, `index`)
+        COMMENT 'Antelope authority waits';
 
 CREATE TABLE IF NOT EXISTS actions
 (

--- a/blocks/antelope/src/authority.rs
+++ b/blocks/antelope/src/authority.rs
@@ -34,7 +34,7 @@ pub fn insert_authority(tables: &mut DatabaseChanges, clock: &Clock, transaction
 
         let keys = authority_keys(tx_hash, &action_index, &index);
         let row = tables
-            .push_change_composite("accounts", keys, 0, table_change::Operation::Create)
+            .push_change_composite("keys", keys, 0, table_change::Operation::Create)
             .change("index", ("", index.to_string().as_str()))
             .change("action_index", ("", action_index.to_string().as_str()))
             .change("public_key", ("", public_key))
@@ -50,7 +50,7 @@ pub fn insert_authority(tables: &mut DatabaseChanges, clock: &Clock, transaction
 
         let keys = authority_keys(tx_hash, &action_index, &index);
         let row = tables
-            .push_change_composite("accounts", keys, 0, table_change::Operation::Create)
+            .push_change_composite("waits", keys, 0, table_change::Operation::Create)
             .change("index", ("", index.to_string().as_str()))
             .change("action_index", ("", action_index.to_string().as_str()))
             .change("wait_sec", ("", wait_sec.to_string().as_str()))

--- a/blocks/antelope/src/authority.rs
+++ b/blocks/antelope/src/authority.rs
@@ -1,0 +1,63 @@
+use crate::{keys::authority_keys, transactions::insert_transaction_metadata};
+use common::blocks::insert_timestamp;
+use substreams::pb::substreams::Clock;
+use substreams_antelope::pb::{Authority, TransactionTrace};
+use substreams_database_change::pb::database::{table_change, DatabaseChanges};
+
+pub fn insert_authority(tables: &mut DatabaseChanges, clock: &Clock, transaction: &TransactionTrace, action_index: u32, authority: &Authority) {
+    let mut index = 0;
+    let tx_hash = &transaction.id;
+
+    // `accounts` TABLE
+    for account in &authority.accounts {
+        let permission_level = account.permission.as_ref().expect("account.permission is missing");
+        let actor = permission_level.actor.as_str();
+        let permission = permission_level.permission.as_str();
+        let weight = account.weight;
+
+        let keys = authority_keys(tx_hash, &action_index, &index);
+        let row = tables
+            .push_change_composite("accounts", keys, 0, table_change::Operation::Create)
+            .change("index", ("", index.to_string().as_str()))
+            .change("action_index", ("", action_index.to_string().as_str()))
+            .change("actor", ("", actor))
+            .change("permission", ("", permission))
+            .change("weight", ("", weight.to_string().as_str()));
+        insert_transaction_metadata(row, transaction);
+        insert_timestamp(row, clock, false, false);
+        index += 1;
+    }
+    // `keys` TABLE
+    for key in &authority.keys {
+        let public_key = key.public_key.as_str();
+        let weight = key.weight;
+
+        let keys = authority_keys(tx_hash, &action_index, &index);
+        let row = tables
+            .push_change_composite("accounts", keys, 0, table_change::Operation::Create)
+            .change("index", ("", index.to_string().as_str()))
+            .change("action_index", ("", action_index.to_string().as_str()))
+            .change("public_key", ("", public_key))
+            .change("weight", ("", weight.to_string().as_str()));
+        insert_transaction_metadata(row, transaction);
+        insert_timestamp(row, clock, false, false);
+        index += 1;
+    }
+    // `waits` TABLE
+    for wait in &authority.waits {
+        let wait_sec = wait.wait_sec;
+        let weight = wait.weight;
+
+        let keys = authority_keys(tx_hash, &action_index, &index);
+        let row = tables
+            .push_change_composite("accounts", keys, 0, table_change::Operation::Create)
+            .change("index", ("", index.to_string().as_str()))
+            .change("action_index", ("", action_index.to_string().as_str()))
+            .change("wait_sec", ("", wait_sec.to_string().as_str()))
+            .change("weight", ("", weight.to_string().as_str()));
+        insert_transaction_metadata(row, transaction);
+        insert_timestamp(row, clock, false, false);
+
+        index += 1;
+    }
+}

--- a/blocks/antelope/src/keys.rs
+++ b/blocks/antelope/src/keys.rs
@@ -67,10 +67,18 @@ pub fn account_ram_delta_keys(clock: &Clock, tx_hash: &String, action_index: &u3
     keys
 }
 
-pub fn perm_ops_keys(clock: &Clock, tx_hash: &String, action_index: &u32) -> HashMap<String, String> {
-    let mut keys = clock_keys(clock);
+pub fn perm_ops_keys(tx_hash: &String, action_index: &u32) -> HashMap<String, String> {
+    let mut keys = HashMap::new();
     keys.insert("tx_hash".to_string(), tx_hash.to_string());
     keys.insert("action_index".to_string(), action_index.to_string());
+    keys
+}
+
+pub fn authority_keys(tx_hash: &str, action_index: &u32, index: &u32) -> HashMap<String, String> {
+    let mut keys = HashMap::new();
+    keys.insert("tx_hash".to_string(), tx_hash.to_string());
+    keys.insert("action_index".to_string(), action_index.to_string());
+    keys.insert("index".to_string(), index.to_string());
     keys
 }
 

--- a/blocks/antelope/src/keys.rs
+++ b/blocks/antelope/src/keys.rs
@@ -67,11 +67,10 @@ pub fn account_ram_delta_keys(clock: &Clock, tx_hash: &String, action_index: &u3
     keys
 }
 
-pub fn perm_ops_keys(clock: &Clock, tx_hash: &String, action_index: &u32, operation: &String) -> HashMap<String, String> {
+pub fn perm_ops_keys(clock: &Clock, tx_hash: &String, action_index: &u32) -> HashMap<String, String> {
     let mut keys = clock_keys(clock);
     keys.insert("tx_hash".to_string(), tx_hash.to_string());
     keys.insert("action_index".to_string(), action_index.to_string());
-    keys.insert("operation".to_string(), operation.to_string());
     keys
 }
 

--- a/blocks/antelope/src/keys.rs
+++ b/blocks/antelope/src/keys.rs
@@ -66,3 +66,11 @@ pub fn account_ram_delta_keys(clock: &Clock, tx_hash: &String, action_index: &u3
     keys.insert("delta".to_string(), delta.to_string());
     keys
 }
+
+pub fn perm_ops_keys(clock: &Clock, tx_hash: &String, action_index: &u32, operation: &String) -> HashMap<String, String> {
+    let mut keys = clock_keys(clock);
+    keys.insert("tx_hash".to_string(), tx_hash.to_string());
+    keys.insert("action_index".to_string(), action_index.to_string());
+    keys.insert("operation".to_string(), operation.to_string());
+    keys
+}

--- a/blocks/antelope/src/lib.rs
+++ b/blocks/antelope/src/lib.rs
@@ -1,6 +1,7 @@
 mod account_ram_deltas;
 mod actions;
 mod auth_sequences;
+mod authority;
 mod authorizations;
 mod blocks;
 mod db_ops;

--- a/blocks/antelope/src/lib.rs
+++ b/blocks/antelope/src/lib.rs
@@ -5,6 +5,7 @@ mod authorizations;
 mod blocks;
 mod db_ops;
 mod keys;
+mod perm_ops;
 mod sinks;
 mod size;
 mod transactions;

--- a/blocks/antelope/src/perm_ops.rs
+++ b/blocks/antelope/src/perm_ops.rs
@@ -23,9 +23,13 @@ pub fn insert_perm_op(tables: &mut DatabaseChanges, clock: &Clock, transaction: 
 
     let old_perm = perm_op.old_perm.clone().unwrap_or_default();
     let new_perm = perm_op.new_perm.clone().unwrap_or_default();
+    let old_nanos = old_perm.last_updated.as_ref().map_or(0, |t| t.nanos);
+    let old_seconds = old_perm.last_updated.as_ref().map_or(0, |t| t.seconds);
+    let new_nanos = new_perm.last_updated.as_ref().map_or(0, |t| t.nanos);
+    let new_seconds = new_perm.last_updated.as_ref().map_or(0, |t| t.seconds);
 
-    // let old_perm_last_updated = block_time_to_date(&old_perm.last_updated.unwrap_or_default().to_string()).to_string();
-    // let new_perm_last_updated = block_time_to_date(&new_perm.last_updated.unwrap_or_default().to_string()).to_string();
+    let old_perm_last_updated_ms = old_seconds * 1000 + i64::from(old_nanos) / 1_000_000;
+    let new_perm_last_updated_ms = new_seconds * 1000 + i64::from(new_nanos) / 1_000_000;
 
     let operation = perm_op_operation_to_string(perm_op.operation);
 
@@ -39,11 +43,11 @@ pub fn insert_perm_op(tables: &mut DatabaseChanges, clock: &Clock, transaction: 
         .change("old_perm_parent_id", ("", old_perm.parent_id.to_string().as_str()))
         .change("old_perm_owner", ("", old_perm.owner.to_string().as_str()))
         .change("old_perm_name", ("", old_perm.name.to_string().as_str()))
-        // .change("old_perm_last_updated", ("", old_perm_last_updated.as_str()))
+        .change("old_perm_last_updated", ("", old_perm_last_updated_ms.to_string().as_str()))
         .change("new_perm_id", ("", new_perm.id.to_string().as_str()))
         .change("new_perm_parent_id", ("", new_perm.parent_id.to_string().as_str()))
         .change("new_perm_owner", ("", new_perm.owner.to_string().as_str()))
-        // .change("new_perm_last_updated", ("", new_perm_last_updated.as_str()))
+        .change("new_perm_last_updated", ("", new_perm_last_updated_ms.to_string().as_str()))
         .change("new_perm_name", ("", new_perm.name.to_string().as_str()));
 
     insert_transaction_metadata(row, transaction);

--- a/blocks/antelope/src/perm_ops.rs
+++ b/blocks/antelope/src/perm_ops.rs
@@ -1,0 +1,51 @@
+use crate::{keys::perm_ops_keys, transactions::insert_transaction_metadata};
+use common::blocks::insert_timestamp;
+use substreams::pb::substreams::Clock;
+use substreams_antelope::pb::{PermOp, TransactionTrace};
+use substreams_database_change::pb::database::{table_change, DatabaseChanges};
+
+pub fn perm_op_operation_to_string(operation: i32) -> String {
+    match operation {
+        0 => "Unknown".to_string(),
+        1 => "Insert".to_string(),
+        2 => "Update".to_string(),
+        3 => "Remove".to_string(),
+        _ => "Unknown".to_string(),
+    }
+}
+
+pub fn insert_perm_op(tables: &mut DatabaseChanges, clock: &Clock, transaction: &TransactionTrace, perm_op: &PermOp) {
+    // transaction
+    let tx_hash = &transaction.id;
+
+    // action
+    let action_index = perm_op.action_index;
+
+    let old_perm = perm_op.old_perm.clone().unwrap_or_default();
+    let new_perm = perm_op.new_perm.clone().unwrap_or_default();
+
+    // let old_perm_last_updated = block_time_to_date(&old_perm.last_updated.unwrap_or_default().to_string()).to_string();
+    // let new_perm_last_updated = block_time_to_date(&new_perm.last_updated.unwrap_or_default().to_string()).to_string();
+
+    let operation = perm_op_operation_to_string(perm_op.operation);
+
+    let keys = perm_ops_keys(clock, tx_hash, &action_index, &operation);
+    let row = tables
+        .push_change_composite("perm_ops", keys, 0, table_change::Operation::Create)
+        .change("tx_hash", ("", tx_hash.as_str()))
+        .change("operation", ("", operation.as_str()))
+        .change("action_index", ("", action_index.to_string().as_str()))
+        .change("old_perm_id", ("", old_perm.id.to_string().as_str()))
+        .change("old_perm_parent_id", ("", old_perm.parent_id.to_string().as_str()))
+        .change("old_perm_owner", ("", old_perm.owner.to_string().as_str()))
+        .change("old_perm_name", ("", old_perm.name.to_string().as_str()))
+        // .change("old_perm_last_updated", ("", old_perm_last_updated.as_str()))
+        .change("new_perm_id", ("", new_perm.id.to_string().as_str()))
+        .change("new_perm_parent_id", ("", new_perm.parent_id.to_string().as_str()))
+        .change("new_perm_owner", ("", new_perm.owner.to_string().as_str()))
+        // .change("new_perm_last_updated", ("", new_perm_last_updated.as_str()))
+        .change("new_perm_name", ("", new_perm.name.to_string().as_str()));
+
+    insert_transaction_metadata(row, transaction);
+    insert_timestamp(row, clock, false, false);
+}

--- a/blocks/antelope/src/transactions.rs
+++ b/blocks/antelope/src/transactions.rs
@@ -1,11 +1,12 @@
 use common::blocks::insert_timestamp;
 use substreams::pb::substreams::Clock;
 use substreams::Hex;
+use substreams_antelope::pb::{BlockHeader, TransactionTrace};
 use substreams_database_change::pb::database::TableChange;
 use substreams_database_change::pb::database::{table_change, DatabaseChanges};
-use substreams_antelope::pb::{BlockHeader, TransactionTrace};
 
 use crate::keys::transactions_keys;
+use crate::perm_ops::insert_perm_op;
 
 use super::actions::insert_action;
 use super::db_ops::insert_db_op;
@@ -56,17 +57,14 @@ pub fn insert_transaction(tables: &mut DatabaseChanges, clock: &Clock, transacti
         .change("elapsed", ("", elapsed.to_string().as_str()))
         .change("net_usage", ("", net_usage.to_string().as_str()))
         .change("scheduled", ("", scheduled.to_string().as_str()))
-
         // header
         .change("cpu_usage_micro_seconds", ("", cpu_usage_micro_seconds.to_string().as_str()))
         .change("net_usage_words", ("", net_usage_words.to_string().as_str()))
         .change("status", ("", status.as_str()))
         .change("status_code", ("", status_code.to_string().as_str()))
         .change("success", ("", success.to_string().as_str()))
-
         // block roots
-        .change("transaction_mroot", ("", transaction_mroot.as_str()))
-        ;
+        .change("transaction_mroot", ("", transaction_mroot.as_str()));
     insert_timestamp(row, clock, false, false);
 
     // TABLE::actions
@@ -104,9 +102,9 @@ pub fn insert_transaction(tables: &mut DatabaseChanges, clock: &Clock, transacti
 
     // TO-DO
     // List of permission changes operations
-    // for perm_op in transaction.perm_ops.iter() {
-    //     insert_perm_op(tables, clock, perm_op, &block);
-    // }
+    for perm_op in transaction.perm_ops.iter() {
+        insert_perm_op(tables, clock, transaction, perm_op);
+    }
 
     // TO-DO
     // List of RAM consumption/redemption


### PR DESCRIPTION
Added the Permission Operations table for Antelope

Caveats : 

- I had some trouble handling the optional nature of the new_perm_last_updated and old_perm_last_updated fields. Not sure what would be the best way to handle this. They're commented out of the schema and table insertion logic for now
- The Authority field in a PermissionObject isn't implemented yet, as it's a quite complex type

![Perm ops select](https://github.com/user-attachments/assets/aa416af4-2801-465e-aed4-a636895613e9)
