### PR TITLE
Antelope : RAM Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ graph TD;
 - [x] **Transactions**
   - [x] **Feature Operations**
   - [ ] **Permission Operations**
-  - [ ] **RAM Operations**
+  - [x] **RAM Operations**
   - [ ] **Table Operations**
   - [ ] **Creation Tree**
   - [ ] ~~**Deferred Transactions**~~

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -112,6 +112,46 @@ CREATE TABLE IF NOT EXISTS feature_ops
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+CREATE TABLE IF NOT EXISTS ram_ops
+(
+    -- clock --
+    block_time    DateTime64(3, 'UTC'),
+    block_number  UInt64,
+    block_hash    String COMMENT 'Hash',
+    block_date    Date,
+
+    -- transaction --
+    tx_hash         String COMMENT 'Hash',
+    tx_index        UInt64,
+    tx_status       LowCardinality(String),
+    tx_status_code  UInt8,
+    tx_success      Bool,
+
+    -- RAM operation --
+    action_index    UInt32,
+    payer           String,
+    delta           Int64,
+    usage           UInt64,
+    namespace       LowCardinality(String),
+    action          LowCardinality(String),
+    unique_key      String
+)
+    ENGINE = ReplacingMergeTree()
+    PRIMARY KEY (block_date, block_number)
+    ORDER BY (block_date, block_number, tx_hash, action_index, unique_key)
+    COMMENT 'Antelope RAM operations';
+
 CREATE TABLE IF NOT EXISTS actions
 (
     -- clock --

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -140,17 +140,20 @@ CREATE TABLE IF NOT EXISTS ram_ops
 
     -- RAM operation --
     operation       LowCardinality(String),
+    operation_code  UInt8,
     action_index    UInt32,
     payer           String,
     delta           Int64,
     usage           UInt64,
     namespace       LowCardinality(String),
+    namespace_code  UInt8,
     action          LowCardinality(String),
+    action_code     UInt8,
     unique_key      String
 )
     ENGINE = ReplacingMergeTree()
-    PRIMARY KEY (block_date, block_number)
-    ORDER BY (block_date, block_number, tx_hash, action_index, unique_key)
+    PRIMARY KEY (tx_hash, action_index, unique_key)
+    ORDER BY (tx_hash, action_index, unique_key)
     COMMENT 'Antelope RAM operations';
 
 CREATE TABLE IF NOT EXISTS actions

--- a/blocks/antelope/schema.sql
+++ b/blocks/antelope/schema.sql
@@ -139,6 +139,7 @@ CREATE TABLE IF NOT EXISTS ram_ops
     tx_success      Bool,
 
     -- RAM operation --
+    operation       LowCardinality(String),
     action_index    UInt32,
     payer           String,
     delta           Int64,

--- a/blocks/antelope/src/keys.rs
+++ b/blocks/antelope/src/keys.rs
@@ -74,3 +74,10 @@ pub fn feature_ops_keys(clock: &Clock, tx_hash: &String, kind: &String, feature_
     keys.insert("feature_digest".to_string(), feature_digest.to_string());
     keys
 }
+
+pub fn ram_op_keys(clock: &Clock, tx_id: &str, unique_key: &str) -> HashMap<String, String> {
+    let mut keys = clock_keys(clock);
+    keys.insert("tx_hash".to_string(), tx_id.to_string());
+    keys.insert("unique_key".to_string(), unique_key.to_string());
+    keys
+}

--- a/blocks/antelope/src/keys.rs
+++ b/blocks/antelope/src/keys.rs
@@ -75,9 +75,10 @@ pub fn feature_ops_keys(clock: &Clock, tx_hash: &String, kind: &String, feature_
     keys
 }
 
-pub fn ram_op_keys(clock: &Clock, tx_id: &str, unique_key: &str) -> HashMap<String, String> {
-    let mut keys = clock_keys(clock);
+pub fn ram_op_keys(tx_id: &str, action_index: &u32, unique_key: &str) -> HashMap<String, String> {
+    let mut keys = HashMap::new();
     keys.insert("tx_hash".to_string(), tx_id.to_string());
+    keys.insert("action_index".to_string(), action_index.to_string());
     keys.insert("unique_key".to_string(), unique_key.to_string());
     keys
 }

--- a/blocks/antelope/src/lib.rs
+++ b/blocks/antelope/src/lib.rs
@@ -6,6 +6,7 @@ mod blocks;
 mod db_ops;
 mod feature_ops;
 mod keys;
+mod ram_ops;
 mod sinks;
 mod size;
 mod transactions;

--- a/blocks/antelope/src/ram_ops.rs
+++ b/blocks/antelope/src/ram_ops.rs
@@ -1,0 +1,62 @@
+use common::blocks::insert_timestamp;
+use substreams::pb::substreams::Clock;
+use substreams_antelope::pb::{RamOp, TransactionTrace};
+use substreams_database_change::pb::database::{table_change, DatabaseChanges};
+
+use crate::keys::ram_op_keys;
+use crate::transactions::insert_transaction_metadata;
+
+pub fn namespace_to_string(namespace: i32) -> String {
+    match namespace {
+        0 => "Unknown".to_string(),
+        1 => "Abi".to_string(),
+        2 => "Account".to_string(),
+        3 => "Auth".to_string(),
+        4 => "AuthLink".to_string(),
+        5 => "Code".to_string(),
+        6 => "DeferredTrx".to_string(),
+        7 => "SecondaryIndex".to_string(),
+        8 => "Table".to_string(),
+        9 => "TableRow".to_string(),
+        _ => "Unknown".to_string(),
+    }
+}
+
+pub fn action_to_string(action: i32) -> String {
+    match action {
+        0 => "Unknown".to_string(),
+        1 => "Add".to_string(),
+        2 => "Cancel".to_string(),
+        3 => "Correction".to_string(),
+        4 => "Push".to_string(),
+        5 => "Remove".to_string(),
+        6 => "Update".to_string(),
+        _ => "Unknown".to_string(),
+    }
+}
+
+pub fn insert_ram_op(tables: &mut DatabaseChanges, clock: &Clock, ram_op: &RamOp, transaction: &TransactionTrace) {
+    let action_index = ram_op.action_index;
+    let payer = &ram_op.payer;
+    let delta = ram_op.delta;
+    let usage = ram_op.usage;
+    let namespace = namespace_to_string(ram_op.namespace);
+
+    let action = action_to_string(ram_op.action);
+
+    let unique_key = &ram_op.unique_key;
+
+    let keys = ram_op_keys(clock, &transaction.id, unique_key);
+    let row = tables
+        .push_change_composite("ram_ops", keys, 0, table_change::Operation::Create)
+        .change("action_index", ("", action_index.to_string().as_str()))
+        .change("payer", ("", payer.as_str()))
+        .change("delta", ("", delta.to_string().as_str()))
+        .change("usage", ("", usage.to_string().as_str()))
+        .change("namespace", ("", namespace.as_str()))
+        .change("action", ("", action.as_str()))
+        .change("unique_key", ("", unique_key.as_str()));
+
+    insert_transaction_metadata(row, transaction);
+    insert_timestamp(row, clock, false, false);
+}

--- a/blocks/antelope/src/ram_ops.rs
+++ b/blocks/antelope/src/ram_ops.rs
@@ -35,7 +35,40 @@ pub fn action_to_string(action: i32) -> String {
     }
 }
 
+pub fn operation_to_string(operation: i32) -> String {
+    match operation {
+        0 => "Unknown".to_string(),
+        1 => "CreateTable".to_string(),
+        2 => "DeferredTrxAdd".to_string(),
+        3 => "DeferredTrxCancel".to_string(),
+        4 => "DeferredTrxPushed".to_string(),
+        5 => "DeferredTrxRamCorrection".to_string(),
+        6 => "DeferredTrxRemoved".to_string(),
+        7 => "DeleteAuth".to_string(),
+        8 => "LinkAuth".to_string(),
+        9 => "NewAccount".to_string(),
+        10 => "PrimaryIndexAdd".to_string(),
+        11 => "PrimaryIndexRemove".to_string(),
+        12 => "PrimaryIndexUpdate".to_string(),
+        13 => "PrimaryIndexUpdateAddNewPayer".to_string(),
+        14 => "PrimaryIndexUpdateRemoveOldPayer".to_string(),
+        15 => "RemoveTable".to_string(),
+        16 => "SecondaryIndexAdd".to_string(),
+        17 => "SecondaryIndexRemove".to_string(),
+        18 => "SecondaryIndexUpdateAddNewPayer".to_string(),
+        19 => "SecondaryIndexUpdateRemoveOldPayer".to_string(),
+        20 => "SetAbi".to_string(),
+        21 => "SetCode".to_string(),
+        22 => "UnlinkAuth".to_string(),
+        23 => "UpdateAuthCreate".to_string(),
+        24 => "UpdateAuthUpdate".to_string(),
+        25 => "Deprecated".to_string(),
+        _ => "Unknown".to_string(),
+    }
+}
+
 pub fn insert_ram_op(tables: &mut DatabaseChanges, clock: &Clock, ram_op: &RamOp, transaction: &TransactionTrace) {
+    let operation = operation_to_string(ram_op.operation);
     let action_index = ram_op.action_index;
     let payer = &ram_op.payer;
     let delta = ram_op.delta;
@@ -49,6 +82,7 @@ pub fn insert_ram_op(tables: &mut DatabaseChanges, clock: &Clock, ram_op: &RamOp
     let keys = ram_op_keys(clock, &transaction.id, unique_key);
     let row = tables
         .push_change_composite("ram_ops", keys, 0, table_change::Operation::Create)
+        .change("operation", ("", operation.as_str()))
         .change("action_index", ("", action_index.to_string().as_str()))
         .change("payer", ("", payer.as_str()))
         .change("delta", ("", delta.to_string().as_str()))

--- a/blocks/antelope/src/ram_ops.rs
+++ b/blocks/antelope/src/ram_ops.rs
@@ -74,21 +74,22 @@ pub fn insert_ram_op(tables: &mut DatabaseChanges, clock: &Clock, ram_op: &RamOp
     let delta = ram_op.delta;
     let usage = ram_op.usage;
     let namespace = namespace_to_string(ram_op.namespace);
-
     let action = action_to_string(ram_op.action);
-
     let unique_key = &ram_op.unique_key;
 
-    let keys = ram_op_keys(clock, &transaction.id, unique_key);
+    let keys = ram_op_keys(&transaction.id, &action_index, unique_key);
     let row = tables
         .push_change_composite("ram_ops", keys, 0, table_change::Operation::Create)
         .change("operation", ("", operation.as_str()))
+        .change("operation_code", ("", ram_op.operation.to_string().as_str()))
         .change("action_index", ("", action_index.to_string().as_str()))
         .change("payer", ("", payer.as_str()))
         .change("delta", ("", delta.to_string().as_str()))
         .change("usage", ("", usage.to_string().as_str()))
         .change("namespace", ("", namespace.as_str()))
+        .change("namespace_code", ("", ram_op.namespace.to_string().as_str()))
         .change("action", ("", action.as_str()))
+        .change("action_code", ("", ram_op.action.to_string().as_str()))
         .change("unique_key", ("", unique_key.as_str()));
 
     insert_transaction_metadata(row, transaction);

--- a/blocks/antelope/src/transactions.rs
+++ b/blocks/antelope/src/transactions.rs
@@ -7,6 +7,7 @@ use substreams_database_change::pb::database::{table_change, DatabaseChanges};
 
 use crate::feature_ops::insert_feature_op;
 use crate::keys::transactions_keys;
+use crate::ram_ops::insert_ram_op;
 
 use super::actions::insert_action;
 use super::db_ops::insert_db_op;
@@ -108,9 +109,9 @@ pub fn insert_transaction(tables: &mut DatabaseChanges, clock: &Clock, transacti
 
     // TO-DO
     // List of RAM consumption/redemption
-    // for ram_op in transaction.ram_ops.iter() {
-    //     insert_ram_op(tables, clock, ram_op, &block);
-    // }
+    for ram_op in transaction.ram_ops.iter() {
+        insert_ram_op(tables, clock, ram_op, transaction);
+    }
 
     // TO-DO
     // List of RAM correction operations (happens only once upon feature activation)


### PR DESCRIPTION
Added the RAM Operations table for Antelope.

Operation field (depecrated, replace by action_index + action) is included for retrocompatiblity

![Clickhouse select eos.ram_ops](https://github.com/user-attachments/assets/d9ba6ceb-e543-4baf-8254-7e4ba777858c)
