### PR TITLE
Solana : Replace instruction and inner_instruction tables with instruction_calls

### DIFF
--- a/blocks/solana/schema.sql
+++ b/blocks/solana/schema.sql
@@ -167,6 +167,45 @@ CREATE TABLE IF NOT EXISTS inner_instructions
     ORDER BY (transaction_id, instruction_index, inner_instruction_index)
     COMMENT 'Solana transaction inner instructions';
 
+
+CREATE TABLE IF NOT EXISTS instruction_calls
+(
+    -- clock --
+    block_time                DateTime64(3, 'UTC'),
+    block_hash                String,
+    block_date                Date,
+
+    -- block --
+    block_slot                UInt64,
+    block_height              UInt64,
+    block_previous_block_hash String,
+    block_parent_slot         UInt64,
+
+    -- transaction --
+    tx_id                     String,
+    tx_index                  UInt32,
+    tx_signer                 String,
+    tx_success                Bool,
+    log_messages              String,
+
+    -- instruction --
+    outer_instruction_index   UInt32,
+    inner_instruction_index   Int32,
+    inner_executing_account   String,
+    outer_executing_account   String,
+    executing_account         String,
+    is_inner                  Bool,
+    `data`                    String,
+    account_arguments         String,
+    inner_instructions        String,
+)
+
+    ENGINE = ReplacingMergeTree()
+    PRIMARY KEY (tx_id, outer_instruction_index, inner_instruction_index)
+    ORDER BY (tx_id, outer_instruction_index, inner_instruction_index)
+    SETTINGS allow_nullable_key = 1
+    COMMENT 'Solana instruction calls';
+
 CREATE TABLE IF NOT EXISTS account_activity 
 (
     -- clock --
@@ -224,6 +263,10 @@ ALTER TABLE inner_instructions ADD PROJECTION IF NOT EXISTS transaction_inner_in
     SELECT * ORDER BY block_date, block_height
 );
 
+ALTER TABLE instruction_calls ADD PROJECTION IF NOT EXISTS instruction_calls_by_block_height (
+    SELECT * ORDER BY block_date, block_height
+);
+
 ALTER TABLE account_activity ADD PROJECTION IF NOT EXISTS account_activity_by_block_height (
     SELECT * ORDER BY block_date, block_height
 );
@@ -238,5 +281,7 @@ ALTER TABLE transactions MATERIALIZE PROJECTION transactions_by_block_height;
 ALTER TABLE instructions MATERIALIZE PROJECTION transaction_instructions_by_block_height;
 
 ALTER TABLE inner_instructions MATERIALIZE PROJECTION transaction_inner_instructions_by_block_height;
+
+ALTER TABLE instruction_calls MATERIALIZE PROJECTION instruction_calls_by_block_height;
 
 ALTER TABLE account_activity MATERIALIZE PROJECTION account_activity_by_block_height;

--- a/blocks/solana/src/instruction_calls.rs
+++ b/blocks/solana/src/instruction_calls.rs
@@ -1,0 +1,111 @@
+use common::utils::bytes_to_hex;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::pb::database::{table_change, DatabaseChanges, TableChange};
+use substreams_solana::{
+    base58,
+    block_view::InstructionView,
+    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction},
+};
+
+use crate::{
+    blocks::insert_blockinfo,
+    keys::{inner_instruction_keys, instruction_keys},
+    utils::{build_csv_string, insert_timestamp_without_number},
+};
+
+pub fn insert_instruction_calls(tables: &mut DatabaseChanges, clock: &Clock, block: &Block, transaction: &ConfirmedTransaction, tx_info: &TxInfo) {
+    transaction.walk_instructions().enumerate().for_each(|(instruction_index, instruction_view)| {
+        insert_outer_instruction(tables, clock, block, tx_info, instruction_index, &instruction_view);
+        insert_inner_instructions(tables, clock, block, tx_info, instruction_index, &instruction_view);
+    });
+}
+
+fn insert_outer_instruction(tables: &mut DatabaseChanges, clock: &Clock, block: &Block, tx_info: &TxInfo, instruction_index: usize, instruction_view: &InstructionView) {
+    let executing_account = base58::encode(instruction_view.program_id());
+    let account_arguments = build_csv_string(&instruction_view.accounts());
+    let data = bytes_to_hex(&instruction_view.data());
+
+    let keys = instruction_keys(tx_info.tx_id, instruction_index.to_string().as_str());
+
+    let inner_instructions_str = build_inner_instructions_str(instruction_view);
+
+    let row = tables
+        .push_change_composite("instruction_calls", keys, 0, table_change::Operation::Create)
+        .change("outer_instruction_index", ("", instruction_index.to_string().as_str()))
+        .change("outer_executing_account", ("", executing_account.as_str()))
+        .change("inner_instruction_index", ("", "-1"))
+        .change("inner_executing_account", ("", ""))
+        .change("executing_account", ("", executing_account.as_str()))
+        .change("is_inner", ("", "false"))
+        .change("data", ("", data.as_str()))
+        .change("account_arguments", ("", account_arguments.as_str()))
+        .change("inner_instructions", ("", inner_instructions_str.as_str()));
+
+    insert_timestamp_without_number(row, clock, false, true);
+    insert_blockinfo(row, block, true);
+    insert_tx_info(row, tx_info);
+}
+
+fn insert_inner_instructions(tables: &mut DatabaseChanges, clock: &Clock, block: &Block, tx_info: &TxInfo, instruction_index: usize, instruction_view: &InstructionView) {
+    for (inner_index, inner_instruction) in instruction_view.inner_instructions().enumerate() {
+        let inner_data = bytes_to_hex(inner_instruction.data());
+        let executing_account = inner_instruction.program_id().to_string();
+        let account_arguments = build_csv_string(&inner_instruction.accounts());
+
+        let keys = inner_instruction_keys(tx_info.tx_id, instruction_index.to_string().as_str(), inner_index.to_string().as_str());
+
+        let row = tables
+            .push_change_composite("instruction_calls", keys, 0, table_change::Operation::Create)
+            .change("outer_instruction_index", ("", instruction_index.to_string().as_str()))
+            .change("inner_instruction_index", ("", inner_index.to_string().as_str()))
+            .change("inner_executing_account", ("", executing_account.as_str()))
+            .change("outer_executing_account", ("", instruction_view.program_id().to_string().as_str()))
+            .change("executing_account", ("", executing_account.as_str()))
+            .change("is_inner", ("", "true"))
+            .change("data", ("", inner_data.as_str()))
+            .change("account_arguments", ("", account_arguments.as_str()))
+            .change("inner_instructions", ("", ""));
+
+        insert_timestamp_without_number(row, clock, false, true);
+        insert_blockinfo(row, block, true);
+        insert_tx_info(row, tx_info);
+    }
+}
+
+fn build_inner_instructions_str(instruction_view: &InstructionView) -> String {
+    let mut inner_instructions_str = String::new();
+
+    let inner_instructions = instruction_view.inner_instructions().enumerate().collect::<Vec<_>>();
+    let last_index = inner_instructions.len().saturating_sub(1);
+
+    for (inner_index, inner_instruction) in inner_instructions {
+        // let inner_data = bytes_to_hex(inner_instruction.data());
+        // TODO: Check why Dune uses base58 encoding for data
+        let inner_data = base58::encode(inner_instruction.data());
+        let executing_account = inner_instruction.program_id().to_string();
+        let account_arguments = build_csv_string(&inner_instruction.accounts());
+
+        inner_instructions_str.push_str(&format!("({},{},{})", inner_data, executing_account, account_arguments));
+        if inner_index != last_index {
+            inner_instructions_str.push_str(", ");
+        }
+    }
+
+    inner_instructions_str
+}
+
+fn insert_tx_info(row: &mut TableChange, tx_info: &TxInfo) {
+    row.change("tx_id", ("", tx_info.tx_id))
+        .change("tx_index", ("", tx_info.tx_index))
+        .change("tx_signer", ("", tx_info.tx_signer))
+        .change("tx_success", ("", tx_info.tx_success))
+        .change("log_messages", ("", tx_info.log_messages));
+}
+
+pub struct TxInfo<'a> {
+    pub tx_id: &'a str,
+    pub tx_index: &'a str,
+    pub tx_signer: &'a str,
+    pub tx_success: &'a str,
+    pub log_messages: &'a str,
+}

--- a/blocks/solana/src/lib.rs
+++ b/blocks/solana/src/lib.rs
@@ -1,6 +1,7 @@
 mod account_activity;
 mod blocks;
 mod counters;
+mod instruction_calls;
 mod instructions;
 mod keys;
 mod rewards;

--- a/blocks/solana/src/transactions.rs
+++ b/blocks/solana/src/transactions.rs
@@ -7,6 +7,7 @@ use substreams_solana::{
 
 use crate::{
     blocks::insert_blockinfo,
+    instruction_calls::{insert_instruction_calls, TxInfo},
     instructions::insert_instructions,
     utils::{build_csv_string, get_account_keys_extended, insert_timestamp_without_number},
 };
@@ -63,7 +64,17 @@ pub fn insert_transactions(tables: &mut DatabaseChanges, clock: &Clock, block: &
         insert_timestamp_without_number(row, clock, false, true);
         insert_blockinfo(row, block, true);
 
-        insert_instructions(tables, clock, block, transaction, index_str.as_str(), &first_signature);
+        // insert_instructions(tables, clock, block, transaction, index_str.as_str(), &first_signature);
+
+        let tx_info = TxInfo {
+            tx_id: &first_signature,
+            tx_index: &index_str,
+            tx_signer: &signer,
+            tx_success: &success.to_string(),
+            log_messages: &log_messages,
+        };
+
+        insert_instruction_calls(tables, clock, block, transaction, &tx_info);
     }
 }
 


### PR DESCRIPTION
This PR proposes replacing the `token_balances` table with the `account_activity` table. The key changes and rationale are as follows:

1. Purpose: The `instruction` and `inner_instruction` tables were originally intended to represent the `instructions` field from the `transactions` table.

2. Redundancy: Upon review, it was determined that the `instructions_calls` table already serves this purpose, covering both instructions and inner instructions.

3. We can do away with the `instruction` field of the `transactions` table, as `instruction_calls` lays the same data out better