### PR TITLE
Refactor Solana collection

### DIFF
--- a/blocks/solana/src/account_activity.rs
+++ b/blocks/solana/src/account_activity.rs
@@ -6,92 +6,90 @@ use crate::{
     utils::get_account_keys_extended,
 };
 
-pub fn collect_account_activities(block_info: &BlockInfo, timestamp: &BlockTimestamp, transactions: &Vec<(usize, &ConfirmedTransaction)>) -> Vec<AccountActivity> {
+pub fn collect_tx_account_activities(transaction: &ConfirmedTransaction, index: usize, block_info: &BlockInfo, timestamp: &BlockTimestamp) -> Vec<AccountActivity> {
     let mut account_activities: Vec<AccountActivity> = Vec::new();
 
-    for (index, transaction) in transactions {
-        let meta = match transaction.meta.as_ref() {
-            Some(m) => m,
-            None => continue, // Skip if metadata is missing
-        };
-        let transaction_id = transaction.id();
-        let transaction_index = index.to_string(); // Consider reusing a buffer if performance is critical
-        let tx_success = meta.err.is_none();
+    let meta = match transaction.meta.as_ref() {
+        Some(m) => m,
+        None => return account_activities, // Return empty vec if metadata is missing
+    };
+    let transaction_id = transaction.id();
+    let transaction_index = index.to_string(); // Consider reusing a buffer if performance is critical
+    let tx_success = meta.err.is_none();
 
-        let trx = match transaction.transaction.as_ref() {
-            Some(t) => t,
-            None => continue, // Skip if transaction data is missing
-        };
+    let trx = match transaction.transaction.as_ref() {
+        Some(t) => t,
+        None => return account_activities, // Return empty vec if transaction data is missing
+    };
 
-        let account_keys_extended = get_account_keys_extended(transaction);
+    let account_keys_extended = get_account_keys_extended(transaction);
 
-        // Precompute a mapping from account_index to pre_token_balance_index
-        let account_to_token_balance_map: Vec<Option<usize>> = {
-            // Determine the maximum account_index to size the vector appropriately
-            let max_account_index = meta.pre_token_balances.iter().map(|balance| balance.account_index as usize).max().unwrap_or(0);
-            let mut map = vec![None; max_account_index + 1];
-            for (i, balance) in meta.pre_token_balances.iter().enumerate() {
-                let idx = balance.account_index as usize;
-                // Assuming that the last occurrence is preferred if duplicates exist
-                map[idx] = Some(i);
-            }
-            map
-        };
-
-        let header = transaction
-            .transaction
-            .as_ref()
-            .and_then(|tx| tx.message.as_ref())
-            .and_then(|msg| msg.header.as_ref())
-            .expect("Transaction message header is missing");
-
-        let writability = determine_writability(header, account_keys_extended.len());
-
-        for (balance_index, (pre_balance, post_balance)) in meta.pre_balances.iter().zip(meta.post_balances.iter()).enumerate() {
-            let address = account_keys_extended.get(balance_index).unwrap();
-
-            // Skip if address is a program derived address
-            if address.ends_with("1111") {
-                continue;
-            }
-
-            // Efficiently retrieve the pre_token_balance_index using the precomputed map
-            let pre_token_balance_index = account_to_token_balance_map.get(balance_index).copied().flatten().unwrap_or(usize::MAX);
-
-            let (pre_token_balance, post_token_balance, token_balance_change, mint, owner) = if pre_token_balance_index != usize::MAX {
-                extract_token_balance_changes(&meta.pre_token_balances, &meta.post_token_balances, pre_token_balance_index)
-            } else {
-                (None, None, None, None, None)
-            };
-
-            let balance_change = *post_balance as i128 - *pre_balance as i128;
-            let signed = is_signed(trx, balance_index);
-            let writable = writability.get(balance_index).unwrap_or(&false);
-
-            account_activities.push(AccountActivity {
-                block_time: Some(timestamp.time),
-                block_hash: timestamp.hash.clone(),
-                block_date: timestamp.date.clone(),
-                block_slot: block_info.slot,
-                block_height: block_info.height,
-                block_previous_block_hash: block_info.previous_block_hash.clone(),
-                block_parent_slot: block_info.parent_slot,
-                address: address.clone(),
-                tx_index: transaction_index.parse().unwrap(),
-                tx_id: transaction_id.clone(),
-                tx_success,
-                signed,
-                writable: *writable,
-                token_mint_address: mint,
-                pre_balance: *pre_balance,
-                post_balance: *post_balance,
-                balance_change: balance_change as i64,
-                pre_token_balance,
-                post_token_balance,
-                token_balance_change,
-                token_balance_owner: owner,
-            });
+    // Precompute a mapping from account_index to pre_token_balance_index
+    let account_to_token_balance_map: Vec<Option<usize>> = {
+        // Determine the maximum account_index to size the vector appropriately
+        let max_account_index = meta.pre_token_balances.iter().map(|balance| balance.account_index as usize).max().unwrap_or(0);
+        let mut map = vec![None; max_account_index + 1];
+        for (i, balance) in meta.pre_token_balances.iter().enumerate() {
+            let idx = balance.account_index as usize;
+            // Assuming that the last occurrence is preferred if duplicates exist
+            map[idx] = Some(i);
         }
+        map
+    };
+
+    let header = transaction
+        .transaction
+        .as_ref()
+        .and_then(|tx| tx.message.as_ref())
+        .and_then(|msg| msg.header.as_ref())
+        .expect("Transaction message header is missing");
+
+    let writability = determine_writability(header, account_keys_extended.len());
+
+    for (balance_index, (pre_balance, post_balance)) in meta.pre_balances.iter().zip(meta.post_balances.iter()).enumerate() {
+        let address = account_keys_extended.get(balance_index).unwrap();
+
+        // Skip if address is a program derived address
+        if address.ends_with("1111") {
+            continue;
+        }
+
+        // Efficiently retrieve the pre_token_balance_index using the precomputed map
+        let pre_token_balance_index = account_to_token_balance_map.get(balance_index).copied().flatten().unwrap_or(usize::MAX);
+
+        let (pre_token_balance, post_token_balance, token_balance_change, mint, owner) = if pre_token_balance_index != usize::MAX {
+            extract_token_balance_changes(&meta.pre_token_balances, &meta.post_token_balances, pre_token_balance_index)
+        } else {
+            (None, None, None, None, None)
+        };
+
+        let balance_change = *post_balance as i128 - *pre_balance as i128;
+        let signed = is_signed(trx, balance_index);
+        let writable = writability.get(balance_index).unwrap_or(&false);
+
+        account_activities.push(AccountActivity {
+            block_time: Some(timestamp.time),
+            block_hash: timestamp.hash.clone(),
+            block_date: timestamp.date.clone(),
+            block_slot: block_info.slot,
+            block_height: block_info.height,
+            block_previous_block_hash: block_info.previous_block_hash.clone(),
+            block_parent_slot: block_info.parent_slot,
+            address: address.clone(),
+            tx_index: transaction_index.parse().unwrap(),
+            tx_id: transaction_id.clone(),
+            tx_success,
+            signed,
+            writable: *writable,
+            token_mint_address: mint,
+            pre_balance: *pre_balance,
+            post_balance: *post_balance,
+            balance_change: balance_change as i64,
+            pre_token_balance,
+            post_token_balance,
+            token_balance_change,
+            token_balance_owner: owner,
+        });
     }
 
     account_activities

--- a/blocks/solana/src/blocks.rs
+++ b/blocks/solana/src/blocks.rs
@@ -14,10 +14,10 @@ pub fn get_block_info(block: &Block) -> BlockInfo {
     }
 }
 
-pub fn collect_block(block: &Block, timestamp: &BlockTimestamp, block_info: &BlockInfo) -> Option<RawBlock> {
+pub fn collect_block(block: &Block, timestamp: &BlockTimestamp, block_info: &BlockInfo) -> RawBlock {
     let counters = get_block_counters(block);
 
-    Some(RawBlock {
+    RawBlock {
         time: Some(timestamp.time),
         date: timestamp.date.clone(),
         hash: timestamp.hash.clone(),
@@ -34,5 +34,5 @@ pub fn collect_block(block: &Block, timestamp: &BlockTimestamp, block_info: &Blo
         successful_non_vote_transactions: counters.successful_non_vote_transactions,
         failed_vote_transactions: counters.failed_vote_transactions,
         failed_non_vote_transactions: counters.failed_non_vote_transactions,
-    })
+    }
 }

--- a/blocks/solana/src/collect_events.rs
+++ b/blocks/solana/src/collect_events.rs
@@ -1,0 +1,79 @@
+use common::structs::BlockTimestamp;
+use substreams::pb::substreams::Clock;
+use substreams_solana::{
+    b58,
+    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction},
+};
+
+use crate::{
+    account_activity::collect_tx_account_activities,
+    blocks::{collect_block, get_block_info},
+    instruction_calls::collect_tx_instruction_calls,
+    pb::solana::Events,
+    rewards::collect_rewards,
+    transactions::collect_transaction,
+    utils::get_timestamp_without_number,
+};
+
+static VOTE_INSTRUCTION: [u8; 32] = b58!("Vote111111111111111111111111111111111111111");
+
+pub fn collect_events_without_votes(block: &Block, clock: &Clock) -> Events {
+    let block_info = get_block_info(block);
+    let timestamp = get_timestamp_without_number(&clock);
+
+    let mut events = Events {
+        blocks: vec![collect_block(block, &timestamp, &block_info)],
+        rewards: collect_rewards(block, &timestamp, &block_info),
+        transactions: vec![],
+        instruction_calls: vec![],
+        account_activity: vec![],
+        vote_transactions: vec![],
+        vote_instruction_calls: vec![],
+        vote_account_activity: vec![],
+    };
+
+    for (index, trx) in block.transactions.iter().enumerate() {
+        events.transactions.push(collect_transaction(trx, index, &block_info, &timestamp));
+        events.instruction_calls.extend(collect_tx_instruction_calls(trx, index, &block_info, &timestamp));
+        events.account_activity.extend(collect_tx_account_activities(trx, index, &block_info, &timestamp));
+    }
+
+    events
+}
+
+pub fn collect_events_with_votes(block: &Block, clock: &Clock) -> Events {
+    let block_info = get_block_info(block);
+    let timestamp = get_timestamp_without_number(&clock);
+
+    let mut events = Events {
+        blocks: vec![collect_block(block, &timestamp, &block_info)],
+        rewards: collect_rewards(block, &timestamp, &block_info),
+        transactions: vec![],
+        instruction_calls: vec![],
+        account_activity: vec![],
+        vote_transactions: vec![],
+        vote_instruction_calls: vec![],
+        vote_account_activity: vec![],
+    };
+
+    let (non_vote_trx, vote_trx): (Vec<(usize, &ConfirmedTransaction)>, Vec<(usize, &ConfirmedTransaction)>) = block.transactions.iter().enumerate().partition(|(_index, trx)| {
+        !trx.transaction
+            .as_ref()
+            .and_then(|t| t.message.as_ref())
+            .map_or(false, |message| message.account_keys.iter().any(|key| key == &VOTE_INSTRUCTION))
+    });
+
+    for (index, trx) in non_vote_trx {
+        events.transactions.push(collect_transaction(trx, index, &block_info, &timestamp));
+        events.instruction_calls.extend(collect_tx_instruction_calls(trx, index, &block_info, &timestamp));
+        events.account_activity.extend(collect_tx_account_activities(trx, index, &block_info, &timestamp));
+    }
+
+    for (index, trx) in vote_trx {
+        events.vote_transactions.push(collect_transaction(trx, index, &block_info, &timestamp));
+        events.vote_instruction_calls.extend(collect_tx_instruction_calls(trx, index, &block_info, &timestamp));
+        events.vote_account_activity.extend(collect_tx_account_activities(trx, index, &block_info, &timestamp));
+    }
+
+    events
+}

--- a/blocks/solana/src/events.rs
+++ b/blocks/solana/src/events.rs
@@ -1,57 +1,16 @@
 use substreams::errors::Error;
 use substreams::pb::substreams::Clock;
-use substreams_solana::b58;
-use substreams_solana::pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction};
+use substreams_solana::pb::sf::solana::r#type::v1::Block;
 
-use crate::account_activity::collect_account_activities;
-use crate::blocks::{collect_block, get_block_info};
-use crate::instruction_calls::collect_instruction_calls;
+use crate::collect_events::{collect_events_with_votes, collect_events_without_votes};
 use crate::pb::solana::Events;
-use crate::rewards::collect_rewards;
-use crate::transactions::collect_transactions;
-use crate::utils::get_timestamp_without_number;
-
-static VOTE_INSTRUCTION: [u8; 32] = b58!("Vote111111111111111111111111111111111111111");
 
 #[substreams::handlers::map]
 pub fn map_events(clock: Clock, block: Block) -> Result<Events, Error> {
-    let timestamp = get_timestamp_without_number(&clock);
-    let block_info = get_block_info(&block);
-
-    let transactions_with_index: Vec<(usize, &ConfirmedTransaction)> = block.transactions.iter().enumerate().collect();
-
-    Ok(Events {
-        blocks: vec![collect_block(&block, &timestamp, &block_info).unwrap()],
-        rewards: collect_rewards(&block, &timestamp, &block_info),
-        transactions: collect_transactions(&transactions_with_index, &block_info, &timestamp),
-        instruction_calls: collect_instruction_calls(&block, &timestamp, &block_info),
-        account_activity: collect_account_activities(&block_info, &timestamp, &transactions_with_index),
-        vote_transactions: vec![],
-        vote_instruction_calls: vec![],
-        vote_account_activity: vec![],
-    })
+    Ok(collect_events_without_votes(&block, &clock))
 }
 
 #[substreams::handlers::map]
 pub fn map_events_with_votes(clock: Clock, block: Block) -> Result<Events, Error> {
-    let timestamp = get_timestamp_without_number(&clock);
-    let block_info = get_block_info(&block);
-
-    let (non_vote_trx, vote_trx): (Vec<(usize, &ConfirmedTransaction)>, Vec<(usize, &ConfirmedTransaction)>) = block.transactions.iter().enumerate().partition(|(_index, trx)| {
-        !trx.transaction
-            .as_ref()
-            .and_then(|t| t.message.as_ref())
-            .map_or(false, |message| message.account_keys.iter().any(|key| key == &VOTE_INSTRUCTION))
-    });
-
-    Ok(Events {
-        blocks: vec![collect_block(&block, &timestamp, &block_info).unwrap()],
-        rewards: collect_rewards(&block, &timestamp, &block_info),
-        transactions: collect_transactions(&non_vote_trx, &block_info, &timestamp),
-        instruction_calls: collect_instruction_calls(&block, &timestamp, &block_info),
-        account_activity: collect_account_activities(&block_info, &timestamp, &non_vote_trx),
-        vote_transactions: collect_transactions(&vote_trx, &block_info, &timestamp),
-        vote_instruction_calls: collect_instruction_calls(&block, &timestamp, &block_info),
-        vote_account_activity: collect_account_activities(&block_info, &timestamp, &vote_trx),
-    })
+    Ok(collect_events_with_votes(&block, &clock))
 }

--- a/blocks/solana/src/lib.rs
+++ b/blocks/solana/src/lib.rs
@@ -1,6 +1,7 @@
 mod account_activity;
 mod blocks;
 mod blocks_without_votes_all;
+mod collect_events;
 mod counters;
 mod events;
 mod instruction_calls;

--- a/blocks/solana/src/transactions.rs
+++ b/blocks/solana/src/transactions.rs
@@ -61,6 +61,54 @@ pub fn collect_transactions(transactions: &Vec<(usize, &ConfirmedTransaction)>, 
     trx_vec
 }
 
+pub fn collect_transaction(transaction: &ConfirmedTransaction, index: usize, block_info: &BlockInfo, timestamp: &BlockTimestamp) -> RawTransaction {
+    let meta = transaction.meta.as_ref().expect("Transaction meta is missing");
+    let trx = transaction.transaction.as_ref().expect("Transaction is missing");
+    let message = trx.message.as_ref().expect("Transaction message is missing");
+    let header = message.header.as_ref().expect("Transaction header is missing");
+
+    let account_keys = get_account_keys_extended(transaction);
+    let success = meta.err.is_none();
+    let err = match &meta.err {
+        Some(err) => decode_transaction_error(&err.err),
+        None => String::new(),
+    };
+
+    let signers = message.account_keys.iter().take(trx.signatures.len()).map(|key| base58::encode(key)).collect::<Vec<String>>();
+    let signers_str = build_csv_string(&signers);
+
+    RawTransaction {
+        block_time: Some(timestamp.time),
+        block_hash: timestamp.hash.clone(),
+        block_date: timestamp.date.clone(),
+        block_slot: block_info.slot,
+        block_height: block_info.height,
+        block_previous_block_hash: block_info.previous_block_hash.clone(),
+        block_parent_slot: block_info.parent_slot,
+        id: transaction.id(),
+        index: index as u32,
+        fee: meta.fee,
+        required_signatures: header.num_required_signatures,
+        required_signed_accounts: header.num_readonly_signed_accounts,
+        required_unsigned_accounts: header.num_readonly_unsigned_accounts,
+        signature: transaction.id(),
+        success,
+        error: err,
+        recent_block_hash: base58::encode(&message.recent_blockhash),
+        account_keys: build_csv_string(&account_keys),
+        log_messages: build_csv_string(&meta.log_messages),
+        // TODO: output as uint array when sink-files supports it
+        pre_balances: build_csv_string(&meta.pre_balances.iter().map(|balance| balance.to_string()).collect::<Vec<String>>()),
+        // TODO: use Array(Text) once sink-files supports it
+        post_balances: build_csv_string(&meta.post_balances.iter().map(|balance| balance.to_string()).collect::<Vec<String>>()),
+        // TODO: use Array(Text) once sink-files supports it
+        signatures: build_csv_string(&trx.signatures.iter().map(|sig| base58::encode(sig)).collect::<Vec<String>>()),
+        signer: message.account_keys.iter().take(trx.signatures.len()).map(|key| base58::encode(key)).next().unwrap(),
+        // TODO: use Array(Text) once sink-files supports it
+        signers: signers_str,
+    }
+}
+
 pub fn decode_transaction_error(err: &Vec<u8>) -> String {
     match TransactionErrorDecoder::decode_error(err) {
         Ok(decoded_error) => TransactionErrorDecoder::format_error(&decoded_error),


### PR DESCRIPTION
Refactored the collection logic of Solana blocks so that we don't iterate through the same `transactions` array multiple times.

Performance difference is hard to tell as the task is connection-bound

For 500 blocks:

## Before refactoring

```bash
make parquet  13.85s user 1.80s system 40% cpu 38.502 total
make parquet  14.34s user 1.81s system 41% cpu 39.327 total
make parquet  14.22s user 1.85s system 41% cpu 39.003 total
```

## After refactoring

```bash
make parquet  14.30s user 1.90s system 40% cpu 39.813 total
make parquet  15.10s user 1.97s system 42% cpu 39.765 total
make parquet  14.84s user 1.94s system 42% cpu 39.550 total
```

